### PR TITLE
Simpler CMake scripting with target usage requirements, CTesting if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,8 @@ set(PYBIND11_PYTHON_VERSION 3.5)
 add_subdirectory(pybind11)
 
 add_subdirectory(source)
+
+include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.18)
+cmake_minimum_required(VERSION 3.8...3.22)
 project(geant4_pybind)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -17,7 +17,6 @@ endif()
 
 find_package(Geant4 10.7 REQUIRED)
 find_package(Geant4 OPTIONAL_COMPONENTS gdml ui_tcsh motif vis_raytracer_x11 vis_opengl_x11 vis_opengl_win32 qt)
-include_directories(${Geant4_INCLUDE_DIRS})
 
 set(PYBIND11_PYTHON_VERSION 3.5)
 add_subdirectory(pybind11)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,5 +1,9 @@
+set(_configure_depends_arg )
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+  set(_configure_depends_arg "CONFIGURE_DEPENDS")
+endif()
 
-file(GLOB_RECURSE SOURCE 
+file(GLOB_RECURSE SOURCE ${_configure_depends_arg}
   analysis/*.cc
   digits_hits/*.cc
   event/*.cc
@@ -19,41 +23,23 @@ file(GLOB_RECURSE SOURCE
   visualization/*.cc
 )
 
-include_directories(.)
-
-if(Geant4_gdml_FOUND)
-  add_definitions(-DG4_HAS_GDML)
-endif()
-
-if(Geant4_ui_tcsh_FOUND)
-  add_definitions(-DG4_HAS_TCSH)
-endif()
-
-if(Geant4_vis_opengl_x11_FOUND)
-  add_definitions(-DG4_HAS_OPENGLX)
-endif()
-
-if(Geant4_vis_raytracer_x11_FOUND)
-  add_definitions(-DG4_HAS_RAYTRACERX)
-endif()
-
-if(Geant4_motif_FOUND)
-  add_definitions(-DG4_HAS_OPENGLXM)
-endif()
-
-if(Geant4_vis_opengl_win32_FOUND)
-  add_definitions(-DG4_HAS_OPENGLWIN)
-endif()
-
-if(Geant4_qt_FOUND)
-  add_definitions(-DG4_HAS_QT)
-endif()
-
-add_definitions(-DPYBIND11_USE_SMART_HOLDER_AS_DEFAULT)
-
 pybind11_add_module(geant4_pybind
   ${SOURCE}
   geant4_pybind.cc
+)
+
+target_include_directories(geant4_pybind PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
+
+target_compile_definitions(geant4_pybind
+  PRIVATE
+    PYBIND11_USE_SMART_HOLDER_AS_DEFAULT
+    $<$<BOOL:${Geant4_gdml_FOUND}>:G4_HAS_GDML>
+    $<$<BOOL:${Geant4_ui_tcsh_FOUND}>:G4_HAS_TCSH>
+    $<$<BOOL:${Geant4_vis_opengl_x11_FOUND}>:G4_HAS_OPENGLX>
+    $<$<BOOL:${Geant4_vis_raytracer_x11_FOUND}>:G4_HAS_RAYTRACERX>
+    $<$<BOOL:${Geant4_motif_FOUND}>:G4_HAS_OPENGLXM>
+    $<$<BOOL:${Geant4_vis_opengl_win32_FOUND}>:G4_HAS_OPENGLWIN>
+    $<$<BOOL:${Geant4_qt_FOUND}>:G4_HAS_QT>
 )
 
 target_link_libraries(geant4_pybind PRIVATE ${Geant4_LIBRARIES})

--- a/source/run/pyG4VUserParallelWorld.cc
+++ b/source/run/pyG4VUserParallelWorld.cc
@@ -23,7 +23,7 @@ public:
 
    void Construct() override { PYBIND11_OVERRIDE_PURE(void, G4VUserParallelWorld, Construct, ); }
 
-   void ConstructSD() { PYBIND11_OVERRIDE_PURE(void, G4VUserParallelWorld, ConstructSD, ); }
+   void ConstructSD() override { PYBIND11_OVERRIDE_PURE(void, G4VUserParallelWorld, ConstructSD, ); }
 };
 
 void export_G4VUserParallelWorld(py::module &m)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Mostly copied from .github workflow
+add_test(NAME test_B1 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_B1.py)
+add_test(NAME test_destruction COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_destruction.py)
+add_test(NAME test_examples COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_examples.py)
+
+set_tests_properties(test_B1 test_destruction test_examples
+  PROPERTIES ENVIRONMENT PYTHONPATH=$<TARGET_FILE_DIR:geant4_pybind>)


### PR DESCRIPTION
A couple of small suggested updates to the CMake scripts using target-based commands:

- Geant4 targets from 10.7 set `INTERFACE_INCLUDE_DIRECTORIES`, so the `include_directories` for Geant4 is not required as linking to the targets will add include paths automatically.
- Needed local path for `geant4_pybind` moved to `target_include_directories`
- Use `target_compile_definitions` for the optional parts with generator expressions to apply when needed
- From CMake 3.12, the `GLOB_RECURSE` can take an extra argument that forces re-CMake-ing if the list of files has changed. Helps build consistency when files moved/added/removed.
- The tests can now be run using CTest if required. Not added to the GitHub action yet.

There's also one minor addition of a missing `override` keyword that caused warnings on macOS.