### PR TITLE
feat: add pre-commit automatic code formatting tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+ci:
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: sort-simple-yaml
+      - id: check-yaml
+      - id: check-xml
+      - id: check-ast
+      - id: check-shebang-scripts-are-executable
+      - id: requirements-txt-fixer
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+      - id: debug-statements
+      - id: name-tests-test
+        args: [--pytest-test-first]
+      - id: pretty-format-json
+        args: [--autofix]
+
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
+    hooks:
+      - id: ruff
+        args: [--fix-only, --show-fixes]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format
+
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+        additional_dependencies: [pyyaml]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.4
+    hooks:
+      - id: prettier
+        types_or: [yaml, toml, markdown, html, css, scss, javascript, json]
+        args: [--prose-wrap=always]

--- a/source/datainit.py
+++ b/source/datainit.py
@@ -1,4 +1,3 @@
-R"(
 
 """Dataset initialization
 
@@ -204,5 +203,3 @@ def init_datasets():
 
 
 init_datasets()
-
-# )"


### PR DESCRIPTION
Add `.pre-commit-config.yaml` configuration file for pre-commit tool.

This will run some code formatting automatically: clang-format, black, formatting cmake files, etc.

The pre-commit bot can be configured to automatically enforce this style in PRs.

I have not formatted the whole repo using this configuration file as it would be a very big diff. If you agree on using pre-commit, we could let the CI bot do it.